### PR TITLE
Tiny fix for Spanish translation

### DIFF
--- a/media/lua/shared/Translate/ES/ContextMenu_ES.txt
+++ b/media/lua/shared/Translate/ES/ContextMenu_ES.txt
@@ -1,4 +1,4 @@
 ContextMenu_ES = {
-	ContextMenu_ThrowCorpseOutTheWindow = "Lanzar cuerpo desde la ventana"
-	ContextMenu_ThrowCorpseOverFence = "Lanzar cuerpo desde la cerca"
+	ContextMenu_ThrowCorpseOutTheWindow = "Lanzar cuerpo por la ventana"
+	ContextMenu_ThrowCorpseOverFence = "Lanzar cuerpo sobre la cerca"
 }

--- a/media/lua/shared/Translate/ES/ContextMenu_ES.utf8.txt
+++ b/media/lua/shared/Translate/ES/ContextMenu_ES.utf8.txt
@@ -1,4 +1,4 @@
 ContextMenu_ES = {
-	ContextMenu_ThrowCorpseOutTheWindow = "Lanzar cuerpo desde la ventana"
-	ContextMenu_ThrowCorpseOverFence = "Lanzar cuerpo desde la cerca"
+	ContextMenu_ThrowCorpseOutTheWindow = "Lanzar cuerpo por la ventana"
+	ContextMenu_ThrowCorpseOverFence = "Lanzar cuerpo sobre la cerca"
 }


### PR DESCRIPTION
Hello!
I updated the translation since it was inconsistent with the English version.
It said "Throw corpse from the window/fence" and I corrected it to "Throw corpse out the window" and "Throw corpse over the fence".